### PR TITLE
Support inner text modification, alternate input/output config XML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The `_` object allows configuration of the plugin itself. All other options affe
 
 `outputPath` can be used to indicate a file to be used (created or modified) as output in case you don't want to modify your source Cordova configuration file or do want to output to a path other than your webpack `context` path (useful for source control where you don't want to trigger a commit for dynamic configuration values or to have more control over the location of your Cordova project). If omitted, `inputPath` is assumed.
 
+Simply omit the `_` options to modify the `config.xml` file in place.
+
 ### Examples
 
 Given the config.xml sample file:

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 Install the plugin:
 
     npm i -D cordova-webpack-config-plugin
-    
+
 CordovaConfigWebpackPlugin will look for `config.xml` relative to the `context` path from `webpack` configuration.
 
-Replace values passed as an object in `config.xml` values. Throws exception if tag passed isn't 
+Replace values passed as an object in `config.xml` values. Throws exception if tag passed isn't
 present in the `config.xml` file.
-  
+
 ### Usage
 
     new CordovaConfigWebpackPlugin({
@@ -28,9 +28,27 @@ present in the `config.xml` file.
 
 ### Examples
 
+Given the config.xml sample file:
+
+    <?xml version='1.0' encoding='utf-8'?>
+    <widget id="com.example.hello" version="1.0.0">
+        <name>HelloWorld</name>
+        <description>
+            A sample Apache Cordova application that responds to the deviceready event.
+        </description>
+        <author email="developer@apache.cordova.com" href="http://cordova.io">
+            Apache Cordova Team
+        </author>
+        <content src="index.html" />
+        <access origin="*" />
+        <a_number>666</a_number>
+    </widget>
+
+Replace the `src` attribute of the  `content` element.
+
     var CordovaConfigWebpackPlugin = require('cordova-webpack-config-plugin');
     var path = require('path');
-    
+
     module.exports = {
         context: path.join(__dirname, 'app'),
         plugins: [
@@ -41,19 +59,24 @@ present in the `config.xml` file.
             })
         ]
     }
-    
+
+Replace the `email` and `href` attributes of the `author` element, and replace the `author` element's inner text using "_".
+
     module.exports = {
         context: path.join(__dirname, 'app'),
         plugins: [
             new CordovaConfigWebpackPlugin({
-                autor: {
+                author: {
+                    _: "Fake Team",
                     email: "fake@fake.invalid",
                     href: "http://fake.invalid"
                 }           
             })
         ]
     }
-    
+
+Replace the inner text of the `name` element which has no attributes.
+
     module.exports = {
         context: path.join(__dirname, 'app'),
         plugins: [
@@ -62,5 +85,5 @@ present in the `config.xml` file.
             })
         ]
     }
-    
+
 ### RoadMap

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Install the plugin:
 
     npm i -D cordova-webpack-config-plugin
     
-CordovaConfigWebpackPlugin will look for `config.xml` into the `context` path from `webpack`.
+CordovaConfigWebpackPlugin will look for `config.xml` relative to the `context` path from `webpack`.
 
-Replace values passed as object into `config.xml` values. Launchs exception if tag passed isn't 
-into the `config.xml`
+Replace values passed as an object in `config.xml` values. Launches exception if tag passed isn't 
+present in the `config.xml` file.
   
 ### Usage
 
@@ -64,6 +64,3 @@ into the `config.xml`
     }
     
 ### RoadMap
-* Add manage of `preferences`
-                
-![](https://www.gnu.org/graphics/gplv3-88x31.png)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Install the plugin:
 
     npm i -D cordova-webpack-config-plugin
     
-CordovaConfigWebpackPlugin will look for `config.xml` relative to the `context` path from `webpack`.
+CordovaConfigWebpackPlugin will look for `config.xml` relative to the `context` path from `webpack` configuration.
 
-Replace values passed as an object in `config.xml` values. Launches exception if tag passed isn't 
+Replace values passed as an object in `config.xml` values. Throws exception if tag passed isn't 
 present in the `config.xml` file.
   
 ### Usage

--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@
 
 Install the plugin:
 
-    npm i -D cordova-webpack-config-plugin
+    npm install --save-dev cordova-webpack-config-plugin
 
-CordovaConfigWebpackPlugin will look for `config.xml` relative to the `context` path from `webpack` configuration.
+CordovaConfigWebpackPlugin will look for `config.xml` or the file specified relative to the `context` path from your webpack configuration.
 
-Replace values passed as an object in `config.xml` values. Throws exception if tag passed isn't
-present in the `config.xml` file.
+Replace values passed as an object in `config.xml` values. Throws exception if tag passed isn't present in the `config.xml` file.
 
 ### Usage
 
     new CordovaConfigWebpackPlugin({
+        _: {
+            inputPath: "path/to/template-config.xml",
+            outputPath: "path/to/cordova-config.xml",
+        },
         content: {
             src: "index.html"
         },
@@ -25,6 +28,11 @@ present in the `config.xml` file.
         ...
     })
 
+The `_` object allows configuration of the plugin itself. All other options affect elements and attributes of the corresponding names in the Cordova configuration file.
+
+`inputPath` can be used to indicate a file to be used as input. If omitted, `config.xml` in your webpack `context` path is assumed.
+
+`outputPath` can be used to indicate a file to be used (created or modified) as output in case you don't want to modify your source Cordova configuration file or do want to output to a path other than your webpack `context` path (useful for source control where you don't want to trigger a commit for dynamic configuration values or to have more control over the location of your Cordova project). If omitted, `inputPath` is assumed.
 
 ### Examples
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,30 +34,25 @@ function CordovaConfigWebpackPlugin(options) {
       if (options) {
         var inputFileName = path.resolve(compiler.context, options._ && options._.inputPath ? options._.inputPath : 'config.xml');
         var xml = parseXml(inputFileName);
+        var xmlRoot = xml.getroot();
         Object.keys(options).forEach(function (tag) {
           if (tag !== '_') {
-            var FIRST = 0;
-            var attr = Object.keys(options[tag])[FIRST];
             if (['string', 'number', 'boolean'].includes(_typeof(options[tag]))) {
               xml.find(tag).text = options[tag];
             } else if (_typeof(options[tag]) === 'object') {
-              if (tag === 'widget') {
-                xml.getroot().attrib[attr] = options[tag][attr];
-              } else {
-                Object.keys(options[tag]).forEach(function (childTag) {
-                  var isInnerTextReplacement = childTag === '_';
-                  var toFind = isInnerTextReplacement ? '' + tag : tag + '[@' + childTag + ']';
-                  var contentTag = xml.find(toFind);
-                  if (contentTag) {
-                    if (isInnerTextReplacement) {
-                      contentTag.text = options[tag][childTag];
-                    }
-                    contentTag.attrib[childTag] = options[tag][childTag];
-                  } else {
-                    throw new Error('No tag named \'' + childTag + '\' found!!');
+              Object.keys(options[tag]).forEach(function (childTag) {
+                var isInnerTextReplacement = childTag === '_';
+                var toFind = isInnerTextReplacement ? '' + tag : tag + '[@' + childTag + ']';
+                var contentTag = xmlRoot.tag === tag ? xmlRoot : xml.find(toFind);
+                if (contentTag) {
+                  if (isInnerTextReplacement) {
+                    contentTag.text = options[tag][childTag];
                   }
-                });
-              }
+                  contentTag.attrib[childTag] = options[tag][childTag];
+                } else {
+                  throw new Error('No tag named \'' + childTag + '\' found!!');
+                }
+              });
             }
           }
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,40 +31,43 @@ function CordovaConfigWebpackPlugin(options) {
 
   var apply = function apply(compiler) {
     compiler.plugin('done', function () {
-      var filename = path.resolve(compiler.context, 'config.xml');
-      var xml = parseXml(filename);
       if (options) {
+        var inputFileName = path.resolve(compiler.context, options._ && options._.inputPath ? options._.inputPath : 'config.xml');
+        var xml = parseXml(inputFileName);
         Object.keys(options).forEach(function (tag) {
-          var FIRST = 0;
-          var attr = Object.keys(options[tag])[FIRST];
-          if (['string', 'number', 'boolean'].includes(_typeof(options[tag]))) {
-            xml.find(tag).text = options[tag];
-          } else if (_typeof(options[tag]) === 'object') {
-            if (tag === 'widget') {
-              xml.getroot().attrib[attr] = options[tag][attr];
-            } else {
-              Object.keys(options[tag]).forEach(function (childTag) {
-                var isInnerTextReplacement = childTag === '_';
-                var toFind = isInnerTextReplacement ? '' + tag : tag + '[@' + childTag + ']';
-                var contentTag = xml.find(toFind);
-                if (contentTag) {
-                  if (isInnerTextReplacement) {
-                    contentTag.text = options[tag][childTag];
+          if (tag !== '_') {
+            var FIRST = 0;
+            var attr = Object.keys(options[tag])[FIRST];
+            if (['string', 'number', 'boolean'].includes(_typeof(options[tag]))) {
+              xml.find(tag).text = options[tag];
+            } else if (_typeof(options[tag]) === 'object') {
+              if (tag === 'widget') {
+                xml.getroot().attrib[attr] = options[tag][attr];
+              } else {
+                Object.keys(options[tag]).forEach(function (childTag) {
+                  var isInnerTextReplacement = childTag === '_';
+                  var toFind = isInnerTextReplacement ? '' + tag : tag + '[@' + childTag + ']';
+                  var contentTag = xml.find(toFind);
+                  if (contentTag) {
+                    if (isInnerTextReplacement) {
+                      contentTag.text = options[tag][childTag];
+                    }
+                    contentTag.attrib[childTag] = options[tag][childTag];
+                  } else {
+                    throw new Error('No tag named \'' + childTag + '\' found!!');
                   }
-                  contentTag.attrib[childTag] = options[tag][childTag];
-                } else {
-                  throw new Error('No tag named \'' + childTag + '\' found!!');
-                }
-              });
+                });
+              }
             }
           }
         });
+        var outputFileName = options._ && options._.outputPath ? path.resolve(compiler.context, options._.outputPath) : inputFileName;
+        fs.writeFileSync(outputFileName, xml.write({
+          indent: 4
+        }), 'utf-8');
       } else {
-        throw new Error('Not config options defined!!');
+        throw new Error('No config options defined!!');
       }
-      fs.writeFileSync(filename, xml.write({
-        indent: 4
-      }), 'utf-8');
     });
   };
   return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,12 +44,16 @@ function CordovaConfigWebpackPlugin(options) {
               xml.getroot().attrib[attr] = options[tag][attr];
             } else {
               Object.keys(options[tag]).forEach(function (childTag) {
-                var toFind = tag + '[@' + childTag + ']';
+                var isInnerTextReplacement = childTag === '_';
+                var toFind = isInnerTextReplacement ? '' + tag : tag + '[@' + childTag + ']';
                 var contentTag = xml.find(toFind);
                 if (contentTag) {
+                  if (isInnerTextReplacement) {
+                    contentTag.text = options[tag][childTag];
+                  }
                   contentTag.attrib[childTag] = options[tag][childTag];
                 } else {
-                  throw new Error('No tag: ' + childTag + ' found!!');
+                  throw new Error('No tag named \'' + childTag + '\' found!!');
                 }
               });
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-webpack-config-plugin",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "A Webpack plugin to modify config.xml in build",
   "main": "lib/index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -40,12 +40,16 @@ function CordovaConfigWebpackPlugin (options) {
               xml.getroot().attrib[attr] = options[tag][attr]
             } else {
               Object.keys(options[tag]).forEach((childTag) => {
-                const toFind = `${tag}[@${childTag}]`
+                const isInnerTextReplacement = childTag === '_'
+                const toFind = isInnerTextReplacement ? `${tag}` : `${tag}[@${childTag}]`
                 let contentTag = xml.find(toFind)
                 if (contentTag) {
+                  if (isInnerTextReplacement) {
+                    contentTag.text = options[tag][childTag]
+                  }
                   contentTag.attrib[childTag] = options[tag][childTag]
                 } else {
-                  throw new Error(`No tag: ${childTag} found!!`)
+                  throw new Error(`No tag named '${childTag}' found!!`)
                 }
               })
             }

--- a/src/index.js
+++ b/src/index.js
@@ -30,30 +30,25 @@ function CordovaConfigWebpackPlugin (options) {
       if (options) {
         let inputFileName = path.resolve(compiler.context, options._ && options._.inputPath ? options._.inputPath : 'config.xml')
         let xml = parseXml(inputFileName)
+        const xmlRoot = xml.getroot()
         Object.keys(options).forEach((tag) => {
           if (tag !== '_') {
-            const FIRST = 0
-            const attr = Object.keys(options[tag])[FIRST]
             if (['string', 'number', 'boolean'].includes(typeof options[tag])) {
               xml.find(tag).text = options[tag]
             } else if (typeof options[tag] === 'object') {
-              if (tag === 'widget') {
-                xml.getroot().attrib[attr] = options[tag][attr]
-              } else {
-                Object.keys(options[tag]).forEach((childTag) => {
-                  const isInnerTextReplacement = childTag === '_'
-                  const toFind = isInnerTextReplacement ? `${tag}` : `${tag}[@${childTag}]`
-                  let contentTag = xml.find(toFind)
-                  if (contentTag) {
-                    if (isInnerTextReplacement) {
-                      contentTag.text = options[tag][childTag]
-                    }
-                    contentTag.attrib[childTag] = options[tag][childTag]
-                  } else {
-                    throw new Error(`No tag named '${childTag}' found!!`)
+              Object.keys(options[tag]).forEach((childTag) => {
+                const isInnerTextReplacement = childTag === '_'
+                const toFind = isInnerTextReplacement ? `${tag}` : `${tag}[@${childTag}]`
+                let contentTag = xmlRoot.tag === tag ? xmlRoot : xml.find(toFind)
+                if (contentTag) {
+                  if (isInnerTextReplacement) {
+                    contentTag.text = options[tag][childTag]
                   }
-                })
-              }
+                  contentTag.attrib[childTag] = options[tag][childTag]
+                } else {
+                  throw new Error(`No tag named '${childTag}' found!!`)
+                }
+              })
             }
           }
         })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,7 +60,7 @@ describe('CordovaConfigWebpackPlugin specs: ', () => {
     expect(parseFile().find('access[@origin]').attrib.origin).to.equal(fakeOptions.access.origin)
   })
 
-  it('Should launch error if not found field in config.xml', () => {
+  it('Should launch error if field not found in config.xml', () => {
     const fakeOptions = {
       fake: {
         origin: 'fakeorigin'
@@ -76,7 +76,7 @@ describe('CordovaConfigWebpackPlugin specs: ', () => {
     expect(err).to.equal(true)
   })
 
-  it('Should be possible replace text elements', () => {
+  it('Should replace text-only elements using element\'s name', () => {
     const multiple = {
       name: 'Custom Content',
       description: 'Custom Content',
@@ -102,6 +102,26 @@ describe('CordovaConfigWebpackPlugin specs: ', () => {
     }
     const cordovaConfigWebpackPlugin = CordovaConfigWebpackPlugin(fakeOptions)
     cordovaConfigWebpackPlugin.apply(MockCompiler)
+    expect(parseFile().find('author[@email]').attrib.email).to.equal(fakeOptions.author.email)
+    expect(parseFile().find('author[@href]').attrib.href).to.equal(fakeOptions.author.href)
+  })
+
+  it('Should change inner text of complex element', () => {
+    const author = {
+      innerText: 'Fake Team',
+      email: 'fake@fake.invalid',
+      repo: 'https://fake.com/fake'
+    }
+    const fakeOptions = {
+      author: {
+        _: author.innerText,
+        email: author.email,
+        href: author.repo
+      }
+    }
+    const cordovaConfigWebpackPlugin = CordovaConfigWebpackPlugin(fakeOptions)
+    cordovaConfigWebpackPlugin.apply(MockCompiler)
+    expect(parseFile().find('author').text).to.equal(fakeOptions.author._)
     expect(parseFile().find('author[@email]').attrib.email).to.equal(fakeOptions.author.email)
     expect(parseFile().find('author[@href]').attrib.href).to.equal(fakeOptions.author.href)
   })


### PR DESCRIPTION
@michogar How do you feel about these changes to support some additional scenarios? I needed a way to change the inner text of some elements (e.g. author) and a way to generate a config.xml file from a template that should not be modified for source-control purposes. I've added appropriate unit tests, as well. 

If you don't approve, I can always rename my fork and create a separate npm package. Thanks for your consideration and for providing a great start to what I needed!